### PR TITLE
CORE-4474/fix-status-error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,23 @@
 # Changelog
 
+## [v3.1.0](https://github.com/octanner/cli-core-auth-plugin/releases/tag/v3.1.0) / 2022-01-26
+
+### New Features
+
+- Improved the responses of the following commands:
+  - `coreauth:client:add-scopes` - now displays a table of `scope_name` and a `status` value of `ADDED` if the scope was just added to easily identify changes
+  - `coreauth:client:add-scopes` - now displays a table of `scope_name` to review the currently assigned scopes
+
+### Bug Fixes
+
+- Resovled the `Cannot read 'status' of undefined error`
+
+### Internal
+
+- Reworded the Note/Warning on the `coreauth:create` command
+- Updated packages to remove security vulnerabilities
+- Increased `akkeris-credential-injector` timeout from 5s -> 10s
+
 ## [v3.0.5](https://github.com/octanner/cli-core-auth-plugin/releases/tag/v3.0.4) / 2021-11-17
 
 ### Internal

--- a/commands/client/addScope.js
+++ b/commands/client/addScope.js
@@ -13,12 +13,21 @@ module.exports = (akkeris, args) => {
   task.start()
 
   return authAxios.post('/coreauth/client/addScope', { app, scope })
-    .then(scope => {
+    .then(response => {
       task.end('ok')
+      if (response.data.CORE_CLIENT_SCOPE) {
+        const scopes = response.data.CORE_CLIENT_SCOPE.split(' ')
+        const formatScopes = scopes.map(scopeName => {
+          return ({
+            scope_name: scopeName,
+            status: scope.includes(scopeName) ? 'ADDED' : ''
+          })
+        })
+        akkeris.terminal.table(formatScopes)
+      }
     })
     .catch(err => {
       task.end('error')
-      akkeris.terminal.error('An error occured while attempting to add Scope(s) to the OAuth Client')
-      akkeris.terminal.error(`${err.response.status} - ${err.response.data.name}: ${err.response.data.message}`)
+      akkeris.terminal.print(err, 'An error occured while attempting to add Scope(s) to the OAuth Client')
     })
 }

--- a/commands/client/create.js
+++ b/commands/client/create.js
@@ -1,35 +1,28 @@
 const buildAxiosWithEnvAndAuth = require('../../utils/auth-axios')
 
 function createClient (akkeris, args) {
-  akkeris.terminal.print('Note: If your app is missing the client_secret configuration, this command will regenerate the client_secret and update the configuration in Akkeris.')
-  const task = akkeris.terminal.task(`Creating OAuth Client for ${args.app}`)
-  task.start()
+  akkeris.terminal.print('* Note: If your app exists in the selected environment, but is missing the CLIENT_SECRET config, this command will regenerate the CLIENT_SECRET and update the config! *')
+  const task = akkeris.terminal.task(`Creating an OAuth Client for: ${args.app}`)
 
   const app = args.app.toLowerCase()
   const type = args.type.toUpperCase()
   const environment = args.environment.toLowerCase()
   const authAxios = buildAxiosWithEnvAndAuth(akkeris, environment)
 
+  task.start()
   return authAxios.post('/coreauth/client/create', {
     app: app,
     redirect_uris: args.postLoginURL,
     returnto_uris: args.postLogoutURL,
     type: type
   })
-    .then((config) => {
-      akkeris.terminal.format_objects((err, config) => {
-        if (err) {
-          akkeris.terminal.error(err)
-          return task.end('error')
-        }
-        return config
-      })
-      return task.end('ok')
+    .then(response => {
+      task.end('ok')
+      akkeris.terminal.vtable(response.data)
     })
     .catch(err => {
       task.end('error')
-      akkeris.terminal.error('An error occured while attempting to create an OAuth Client')
-      akkeris.terminal.error(`${err.response.status} - ${err.response.data.name}: ${err.response.data.message}`)
+      akkeris.terminal.error('An error occured while attempting to create an OAuth Client', err)
     })
 }
 

--- a/commands/client/deactivate.js
+++ b/commands/client/deactivate.js
@@ -22,14 +22,12 @@ function deactivateClient (akkeris, args) {
         .then(() => configTask.end('ok'))
         .catch(err => {
           task.end('error')
-          akkeris.terminal.error('An error occured while attempting to remove the config from Akkeris')
-          akkeris.terminal.error(`${err.response.status} - ${err.response.data.name}: ${err.response.data.message}`)
+          akkeris.terminal.error('An error occured while attempting to remove the config from Akkeris', err)
         })
     })
     .catch(err => {
       task.end('error')
-      akkeris.terminal.error('An error occured while attempting to deactivate your OAuth Client')
-      akkeris.terminal.error(`${err.response.status} - ${err.response.data.name}: ${err.response.data.message}`)
+      akkeris.terminal.error('An error occured while attempting to deactivate your OAuth Client', err)
     })
 }
 

--- a/commands/client/regenerate.js
+++ b/commands/client/regenerate.js
@@ -14,8 +14,7 @@ function regenerateClient (akkeris, args) {
     .then(() => task.end('ok'))
     .catch(err => {
       task.end('error')
-      akkeris.terminal.error('An error occured while attempting to regenerate the OAuth Client\'s secret')
-      akkeris.terminal.error(`${err.response.status} - ${err.response.data.name}: ${err.response.data.message}`)
+      akkeris.terminal.error('An error occured while attempting to regenerate the OAuth Client\'s secret', err)
     })
 }
 

--- a/commands/client/remove.js
+++ b/commands/client/remove.js
@@ -2,7 +2,7 @@
 
 function filterConfig (config) {
   return Object.keys(config)
-    .filter((key) => key.startsWith('CORE_AUTH_'))
+    .filter((key) => key.startsWith('CORE_AUTH_') || key.startsWith('CORE_CLIENT_'))
     .reduce((res, key) => ((res[key] = null), res), {}) // eslint-disable-line no-sequences
 }
 
@@ -32,8 +32,7 @@ function removeClient (akkeris, args) {
     .then(() => task.end('ok'))
     .catch(err => {
       task.end('error')
-      akkeris.terminal.error('An error occured while attempting to remove your Core Auth Configuration from Akkeris')
-      akkeris.terminal.error(`${err.response.status} - ${err.response.data.name}: ${err.response.data.message}`)
+      akkeris.terminal.error('An error occured while attempting to remove your Core Auth Configuration from Akkeris', err)
     })
 }
 

--- a/commands/client/removeScope.js
+++ b/commands/client/removeScope.js
@@ -13,12 +13,20 @@ module.exports = (akkeris, args) => {
   task.start()
 
   return authAxios.post('/coreauth/client/removeScope', { app, scope })
-    .then(scope => {
+    .then(response => {
       task.end('ok')
+      if (response.data.CORE_CLIENT_SCOPE) {
+        const scopes = response.data.CORE_CLIENT_SCOPE.split(' ')
+        const formatScopes = scopes.map(scopeName => {
+          return ({
+            scope_name: scopeName
+          })
+        })
+        akkeris.terminal.table(formatScopes)
+      }
     })
     .catch(err => {
       task.end('error')
-      akkeris.terminal.error('An error occured while attempting to remove Scope(s) from the OAuth Client')
-      akkeris.terminal.error(`${err.response.status} - ${err.response.data.name}: ${err.response.data.message}`)
+      akkeris.terminal.print(err, 'An error occured while attempting to add Scope(s) to the OAuth Client')
     })
 }

--- a/commands/client/update.js
+++ b/commands/client/update.js
@@ -20,8 +20,7 @@ async function updateClient (akkeris, args) {
     .then(() => task.end('ok'))
     .catch(err => {
       task.end('error')
-      akkeris.terminal.error('An error occured while attempting to update your OAuth Client')
-      akkeris.terminal.error(`${err.response.status} - ${err.response.data.name}: ${err.response.data.message}`)
+      akkeris.terminal.error('An error occured while attempting to update your OAuth Client', err)
     })
 }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,8 +8,8 @@
       "name": "cli-core-auth-akkeris-plugin",
       "version": "3.0.5",
       "dependencies": {
-        "axios": "^0.24.0",
-        "ramda": "^0.27.1"
+        "axios": "^0.25.0",
+        "ramda": "^0.28.0"
       },
       "devDependencies": {
         "standard": "^16.0.4"
@@ -273,11 +273,11 @@
       }
     },
     "node_modules/axios": {
-      "version": "0.24.0",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-0.24.0.tgz",
-      "integrity": "sha512-Q6cWsys88HoPgAaFAVUb0WpPk0O8iTeisR9IMqy9G8AbO4NlpVknrnQS03zzF9PGAWgO3cgletO3VjV/P7VztA==",
+      "version": "0.25.0",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-0.25.0.tgz",
+      "integrity": "sha512-cD8FOb0tRH3uuEe6+evtAbgJtfxr7ly3fQjYcMcuPlgkwVS9xboaVIpcDV+cYQe+yGykgwZCs1pzjntcGa6l5g==",
       "dependencies": {
-        "follow-redirects": "^1.14.4"
+        "follow-redirects": "^1.14.7"
       }
     },
     "node_modules/balanced-match": {
@@ -1042,9 +1042,9 @@
       "dev": true
     },
     "node_modules/follow-redirects": {
-      "version": "1.14.5",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.14.5.tgz",
-      "integrity": "sha512-wtphSXy7d4/OR+MvIFbCVBDzZ5520qV8XfPklSN5QtxuMUJZ+b0Wnst1e1lCDocfzuCkHqj8k0FpZqO+UIaKNA==",
+      "version": "1.14.7",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.14.7.tgz",
+      "integrity": "sha512-+hbxoLbFMbRKDwohX8GkTataGqO6Jb7jGwpAlwgy2bIz25XtRm7KEzJM76R1WiNT5SwZkX4Y75SwBolkpmE7iQ==",
       "funding": [
         {
           "type": "individual",
@@ -2106,9 +2106,13 @@
       }
     },
     "node_modules/ramda": {
-      "version": "0.27.1",
-      "resolved": "https://registry.npmjs.org/ramda/-/ramda-0.27.1.tgz",
-      "integrity": "sha512-PgIdVpn5y5Yns8vqb8FzBUEYn98V3xcPgawAkkgj0YJ0qDsnHCiNmZYfOGMgOvoB0eWFLpYbhxUR3mxfDIMvpw=="
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/ramda/-/ramda-0.28.0.tgz",
+      "integrity": "sha512-9QnLuG/kPVgWvMQ4aODhsBUFKOUmnbUnsSXACv+NCQZcHbeb+v8Lodp8OVxtRULN1/xOyYLLaL6npE6dMq5QTA==",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/ramda"
+      }
     },
     "node_modules/react-is": {
       "version": "16.13.1",
@@ -2871,11 +2875,11 @@
       "dev": true
     },
     "axios": {
-      "version": "0.24.0",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-0.24.0.tgz",
-      "integrity": "sha512-Q6cWsys88HoPgAaFAVUb0WpPk0O8iTeisR9IMqy9G8AbO4NlpVknrnQS03zzF9PGAWgO3cgletO3VjV/P7VztA==",
+      "version": "0.25.0",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-0.25.0.tgz",
+      "integrity": "sha512-cD8FOb0tRH3uuEe6+evtAbgJtfxr7ly3fQjYcMcuPlgkwVS9xboaVIpcDV+cYQe+yGykgwZCs1pzjntcGa6l5g==",
       "requires": {
-        "follow-redirects": "^1.14.4"
+        "follow-redirects": "^1.14.7"
       }
     },
     "balanced-match": {
@@ -3455,9 +3459,9 @@
       "dev": true
     },
     "follow-redirects": {
-      "version": "1.14.5",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.14.5.tgz",
-      "integrity": "sha512-wtphSXy7d4/OR+MvIFbCVBDzZ5520qV8XfPklSN5QtxuMUJZ+b0Wnst1e1lCDocfzuCkHqj8k0FpZqO+UIaKNA=="
+      "version": "1.14.7",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.14.7.tgz",
+      "integrity": "sha512-+hbxoLbFMbRKDwohX8GkTataGqO6Jb7jGwpAlwgy2bIz25XtRm7KEzJM76R1WiNT5SwZkX4Y75SwBolkpmE7iQ=="
     },
     "fs.realpath": {
       "version": "1.0.0",
@@ -4233,9 +4237,9 @@
       "dev": true
     },
     "ramda": {
-      "version": "0.27.1",
-      "resolved": "https://registry.npmjs.org/ramda/-/ramda-0.27.1.tgz",
-      "integrity": "sha512-PgIdVpn5y5Yns8vqb8FzBUEYn98V3xcPgawAkkgj0YJ0qDsnHCiNmZYfOGMgOvoB0eWFLpYbhxUR3mxfDIMvpw=="
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/ramda/-/ramda-0.28.0.tgz",
+      "integrity": "sha512-9QnLuG/kPVgWvMQ4aODhsBUFKOUmnbUnsSXACv+NCQZcHbeb+v8Lodp8OVxtRULN1/xOyYLLaL6npE6dMq5QTA=="
     },
     "react-is": {
       "version": "16.13.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "cli-core-auth-akkeris-plugin",
-  "version": "3.0.5",
+  "version": "3.1.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "cli-core-auth-akkeris-plugin",
-      "version": "3.0.5",
+      "version": "3.1.0",
       "dependencies": {
         "axios": "^0.25.0",
         "ramda": "^0.28.0"

--- a/package.json
+++ b/package.json
@@ -20,8 +20,8 @@
     "lint": "standard --fix 'plugin.js' 'commands/**/*.js' 'utils/*.js'"
   },
   "dependencies": {
-    "axios": "^0.24.0",
-    "ramda": "^0.27.1"
+    "axios": "^0.25.0",
+    "ramda": "^0.28.0"
   },
   "devDependencies": {
     "standard": "^16.0.4"

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "cli-core-auth-akkeris-plugin",
   "description": "Akkeris CLI plugin for Apps to create and manage their OAuth Client with Core Auth",
   "private": true,
-  "version": "3.0.5",
+  "version": "3.1.0",
   "author": "Jan Taylor <jan.taylor@octanner.com>",
   "maintainers": [
     "Tyler Evans <tyler.evans-ct@octanner.com>"

--- a/utils/auth-axios.js
+++ b/utils/auth-axios.js
@@ -4,7 +4,7 @@ const environments = require('./environments')
 const verifyEnv = function (environment) {
   if (!environment) throw new Error('The Environment was not passed')
 
-  var env = environments[environment.toLowerCase()]
+  const env = environments[environment.toLowerCase()]
   if (!env) throw new Error(`The Environment passed: ${environment} does not exist`)
 
   return env
@@ -12,7 +12,7 @@ const verifyEnv = function (environment) {
 
 const createAxiosWithAuth = (env, account) => axios.create({
   baseURL: env.url,
-  timeout: 5000,
+  timeout: 10000,
   headers: {
     Authorization: `Bearer ${account.password}`,
     'x-username': `${account.password}`


### PR DESCRIPTION
### New Features

- Improved the responses of the following commands:
  - `coreauth:client:add-scopes` - now displays a table of `scope_name` and a `status` value of `ADDED` if the scope was just added to easily identify changes
  - `coreauth:client:add-scopes` - now displays a table of `scope_name` to review the currently assigned scopes

### Bug Fixes

- Resovled the `Cannot read 'status' of undefined error`

### Internal

- Reworded the Note/Warning on the `coreauth:create` command
- Updated packages to remove security vulnerabilities
- Increased `akkeris-credential-injector` timeout from 5s -> 10s