### PR TITLE
CORE-6927/fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,19 @@
 # Changelog
 
+## [v4.0.0](https://github.com/octanner/cli-core-auth-plugin/releases/tag/v4.0.0) / 2023-06-15
+
+### Breaking Changes
+
+- Removed the deprecated `coreauth:client:regenerate` command. Please use `coreauth:client:regenerate-secret` instead
+- Removed the option for `-s` `--scope` and `-f` `--feature` from the `coreauth:client:create` and `coreauth:client:update` commands as they were not adding the scopes to the OAuth Client.
+  - **Note: Please use the `coreauth:client:add-scope` command after you have created your client or have updated it**
+
+### Internal
+
+- Fixed the `-e` `--environment` option, to include the `GAM` (Gamma) environment as an option
+- Fixed the `-t` `--type` option, removing the unused `INTROSPECTION` type which has not been released
+
+
 ## [v3.2.3](https://github.com/octanner/cli-core-auth-plugin/releases/tag/v3.2.3) / 2023-06-09
 
 ### Internal

--- a/commands/client.js
+++ b/commands/client.js
@@ -15,7 +15,13 @@ module.exports = {
       .command(
         'coreauth:client:create',
         'Create OAuth2 Client credentials and assign them to the specified app',
-        sharedArgs,
+        {
+          app: sharedArgs.app,
+          postLoginURL: sharedArgs.postLoginURL,
+          postLogoutURL: sharedArgs.postLogoutURL,
+          type: sharedArgs.type,
+          environment: sharedArgs.environment
+        },
         create.bind(null, akkeris)
       )
       .command(
@@ -26,15 +32,6 @@ module.exports = {
           environment: sharedArgs.environment
         },
         deactivate.bind(null, akkeris)
-      )
-      .command(
-        'coreauth:client:regenerate',
-        'Deprecated: See \'coreauth:client:regenerate-secret\'',
-        {
-          app: sharedArgs.app,
-          environment: sharedArgs.environment
-        },
-        regenerate.bind(null, akkeris)
       )
       .command(
         'coreauth:client:regenerate-secret',
@@ -56,7 +53,13 @@ module.exports = {
       .command(
         'coreauth:client:update',
         'Update the OAuth Client and add/update the config for the specified app',
-        sharedArgs,
+        {
+          app: sharedArgs.app,
+          postLoginURL: sharedArgs.postLoginURL,
+          postLogoutURL: sharedArgs.postLogoutURL,
+          type: sharedArgs.type,
+          environment: sharedArgs.environment
+        },
         update.bind(null, akkeris)
       )
       .command(

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "cli-core-auth-akkeris-plugin",
-  "version": "3.2.3",
+  "version": "4.0.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "cli-core-auth-akkeris-plugin",
-      "version": "3.2.3",
+      "version": "4.0.0",
       "dependencies": {
         "axios": "^1.4.0",
         "ramda": "^0.29.0"

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "cli-core-auth-akkeris-plugin",
   "description": "Akkeris CLI plugin for Apps to create and manage their OAuth Client with Core Auth",
   "private": true,
-  "version": "3.2.3",
+  "version": "4.0.0",
   "author": "Jan Taylor <jan.taylor@octanner.com>",
   "maintainers": [
     "Tyler Evans <tyler.evans-ct@octanner.com>"

--- a/utils/shared-arguments.js
+++ b/utils/shared-arguments.js
@@ -45,7 +45,7 @@ module.exports = {
     string: true,
     demand: true,
     description:
-        'type - Choose one: [WEB|MOBILE|API|INTROSPECTION]. The type of OAuth Client your app needs will restrict it from authorizing on behalf of users or itself'
+        'type - Choose one: [WEB|MOBILE|API]. The type of OAuth Client your app needs will restrict it from authorizing on behalf of users or itself'
   },
 
   environment: {
@@ -53,6 +53,6 @@ module.exports = {
     string: true,
     demand: true,
     description:
-        'environment - Choose one: [QA|STG|PRD]. Which Core environment will your app be connecting with? (Note: QA should be Core Team only)'
+        'environment - Choose one: [QA|STG|GAM|PRD]. Which Core environment will your app be connecting with?'
   }
 }


### PR DESCRIPTION
## [v4.0.0](https://github.com/octanner/cli-core-auth-plugin/releases/tag/v4.0.0) / 2023-06-15

### Breaking Changes

- Removed the deprecated `coreauth:client:regenerate` command. Please use `coreauth:client:regenerate-secret` instead
- Removed the option for `-s` `--scope` and `-f` `--feature` from the `coreauth:client:create` and `coreauth:client:update` commands as they were not adding the scopes to the OAuth Client.
  - **Note: Please use the `coreauth:client:add-scope` command after you have created your client or have updated it**

### Internal

- Fixed the `-e` `--environment` option, to include the `GAM` (Gamma) environment as an option
- Fixed the `-t` `--type` option, removing the unused `INTROSPECTION` type which has not been released